### PR TITLE
Change the Google sign in process

### DIFF
--- a/src/lib/api/sheet.ts
+++ b/src/lib/api/sheet.ts
@@ -7,7 +7,7 @@ import {
 } from '$lib/types';
 import { PUBLIC_APP_SCRIPT_URL } from '$env/static/public';
 import { mockWordItems } from './mock';
-import { getValidTokenOrPrompt } from '$lib/auth';
+import { getTokenIfValid } from '$lib/auth';
 
 const ENDPOINT = PUBLIC_APP_SCRIPT_URL; // .env 讀
 
@@ -47,7 +47,7 @@ export async function getWordListFromSheet(): Promise<WordItem[]> {
 // }
 
 export async function updateReviewToSheet(updateFields: UpdateFields): Promise<void> {
-	const idToken = await getValidTokenOrPrompt();
+	const idToken = getTokenIfValid();
 	if (!idToken) {
 		throw new Error('No valid token for updateReview');
 	}
@@ -56,7 +56,7 @@ export async function updateReviewToSheet(updateFields: UpdateFields): Promise<v
 		method: 'POST',
 		body: JSON.stringify({
 			op: 'updateRows',
-		  id_token: idToken.token,
+		  id_token: idToken,
 			fields: updateFields,
 		}),
 	});

--- a/src/lib/stores/auth.ts
+++ b/src/lib/stores/auth.ts
@@ -1,0 +1,7 @@
+import { writable } from 'svelte/store';
+
+export const isSignedIn = writable<boolean>(false);
+
+export function setSignIn() {
+    isSignedIn.set(true);
+}

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -2,13 +2,18 @@ import type { LayoutLoad } from './$types';
 import { browser } from '$app/environment';
 import { redirect } from '@sveltejs/kit';
 import { getIsSignedIn } from '$lib/auth';
+import { setSignIn } from '$lib/stores/auth';
 import { base } from '$app/paths'; // using the paths.base set in svelte.config.js
 
 export const load: LayoutLoad = async ({ url }) => {
     // 僅在瀏覽器端檢查（localStorage 僅存在於瀏覽器）
     if (browser) {
         const isHome = url.pathname === `${base}/`;
-        if (!isHome && !getIsSignedIn()) {
+        const isLocalStorageSignedIn = getIsSignedIn();
+        if (isLocalStorageSignedIn) {
+            setSignIn();
+        }
+        if (!isHome && !isLocalStorageSignedIn) {
             throw redirect(307, `${base}/`);
         }
     }


### PR DESCRIPTION
## Summery

原本：頁面用自製「Login」按鈕 → 點擊時 initialize() + prompt()；notDisplayed / skipped 當錯誤處理。

問題：
- 使用者關閉 One Tap 或進入冷卻期（suppressed_by_user）後，再按自製按鈕也無法顯示，造成卡關。[Google for Developers](https://developers.google.com/identity/gsi/web/guides/features?utm_source=chatgpt.com)
- 在點擊事件裡多次呼叫 initialize()，可能覆蓋 callback/造成競態。

現在：
改為只使用官方 renderButton 作為主要登入入口；initialize() 僅執行一次；登入成功直接更新 isSignedIn 狀態。官方按鈕屬於顯式點擊，不受 One Tap 的壓抑/冷卻機制影響，使用者可重試。
Google for Developers
+1

## Original solution

- 自製按鈕點擊 → 執行 google.accounts.id.initialize({...}) → google.accounts.id.prompt(...)。
- 若使用者關閉提示或被壓抑，notification.isNotDisplayed() / isSkippedMoment() → reject() 當作錯誤。
- 導致在冷卻期內怎麼按都不會再出現提示。[Google for Developers](https://developers.google.com/identity/gsi/web/guides/display-google-one-tap?utm_source=chatgpt.com)


## New Changes

### 改用官方 Sign in with Google 按鈕

以 google.accounts.id.renderButton(el, options) 渲染按鈕，作為唯一登入入口。
Google for Developers
+1

### 初始化只做一次

- 在元件掛載時執行 google.accounts.id.initialize({ client_id, callback, cancel_on_tap_outside: false, use_fedcm_for_prompt: true })，避免多次覆蓋。
- cancel_on_tap_outside: false 可降低誤觸關閉。[Google for Developers](https://developers.google.com/identity/gsi/web/guides/display-google-one-tap?utm_source=chatgpt.com)

### 移除登入頁的 One Tap 依賴

1. 登入頁不再呼叫 prompt()；需要「可重試」時，由使用者再次點官方按鈕。
2. 其他頁若要「嘗試」One Tap，可在初始化後呼叫 prompt() 並監聽 isSkippedMoment()，但失敗不擋流程。[Google for Developers](https://developers.google.com/identity/gsi/web/guides/display-google-one-tap?utm_source=chatgpt.com)

### 狀態更新

- callback 收到 credential 後完成白名單/exp 驗證，儲存 token，並 isSignedIn.set(true)。

## 影響與好處

- 穩定可重試：官方按鈕不受 One Tap 冷卻/壓抑影響；關掉也可再點一次登入。[Google for Developers](https://developers.google.com/identity/gsi/web/guides/display-button?utm_source=chatgpt.com)
- 更貼近官方建議：將按鈕當主要入口、One Tap 僅作加分。[Google for Developers](https://developers.google.com/identity/gsi/web/guides/display-google-one-tap?utm_source=chatgpt.com)
- 少競態：initialize() 單例化，避免多次覆蓋 callback。


## 參考資料（官方）

- JS 參考：renderButton / initialize / prompt moment 通知（含 isSkippedMoment 範例）。[Google for Developers](https://developers.google.com/identity/gsi/web/reference/js-reference?utm_source=chatgpt.com)
- 顯示 One Tap（含 cancel_on_tap_outside、moment callback 說明）。[Google for Developers](https://developers.google.com/identity/gsi/web/guides/display-google-one-tap?utm_source=chatgpt.com)
- 顯示 Sign in with Google 按鈕（官方導引）。[Google for Developers](https://developers.google.com/identity/gsi/web/guides/display-button?utm_source=chatgpt.com)
- One Tap 行為與冷卻期、使用者可全域關閉提示。[Google for Developers](https://developers.google.com/identity/gsi/web/guides/features?utm_source=chatgpt.com)
- 遷移至 FedCM：移除部分 display/skipped reason API 的依賴（行為更新指引）。[Google for Developers](https://developers.google.com/identity/gsi/web/guides/fedcm-migration?utm_source=chatgpt.com)
